### PR TITLE
Fix state being overriden in address forms

### DIFF
--- a/app/views/spree/admin/shared/_address_form.html.erb
+++ b/app/views/spree/admin/shared/_address_form.html.erb
@@ -38,7 +38,6 @@
 <% content_for :head do %>
   <script>
     document.addEventListener("spree:load", function() {
-      updateAddressState('<%= s_or_b %>');
       $('#<%= s_or_b %>country select').on('change', function() { updateAddressState('<%= s_or_b %>'); });
     })
   </script>


### PR DESCRIPTION
## Issue
The state field in address forms in the admin panel (e.g. `/admin/users/<id>/addresses` or `/admin/orders/<id>/customer`) is overriden with the first state in alphabetical order.

Clearly visible when refreshing the page - the state is correct at first (in this case Colorado) and after a moment it gets overriden with Alabama:

https://user-images.githubusercontent.com/43988137/169048725-99562561-589b-4db6-a270-4a6e95634758.mov


## Steps to reproduce
1. Create an user with a shipping address that has a state (e.g. from the United States)
2. Visit the `/admin/users/<id>/addresses` page

or

1. Create an order with a shipping address that has a state (e.g. from the United States)
2. Visit `/admin/orders/<id>/customer` page

## Cause
After the page is loaded, the [updateAddressState](https://github.com/spree/spree_backend/blob/main/app/assets/javascripts/spree/backend/address_states.es6) function is called. It updates the list of available states for the selected country which overrides the pre-selected one.

Calling the update function was useful when the form object wasn't initialized (default country and empty state). It made so the state is set to the first state by default. So originally you'd see this:

![old_initial_state](https://user-images.githubusercontent.com/43988137/169059451-bb142913-0ca9-4d87-b8cc-a21325785653.png)

instead of this:

![new_initial_state](https://user-images.githubusercontent.com/43988137/169059512-4e220adb-00b0-4ae6-874b-b057682a4be5.png)
